### PR TITLE
refactor: Remove worker name from configuration hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1025,7 +1025,7 @@ export default {
                   uri.searchParams.set("security", port == 443 ? "tls" : "none");
                   uri.searchParams.set("sni", port == 443 ? APP_DOMAIN : "");
                   uri.searchParams.set("path", `/${prx.prxIP}-${prx.prxPort}`);
-                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} VLESS/WS/${port == 443 ? "TLS" : "NTLS"} [${serviceName}]`;
+                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} VLESS/WS/${port == 443 ? "TLS" : "NTLS"}`;
                 } else if (protocol == atob(horse)) { // Trojan
                   uri.searchParams.set("encryption", "none");
                   uri.searchParams.set("type", "ws");
@@ -1034,14 +1034,14 @@ export default {
                   uri.searchParams.set("security", port == 443 ? "tls" : "none");
                   uri.searchParams.set("sni", port == 443 ? APP_DOMAIN : "");
                   uri.searchParams.set("path", `/${prx.prxIP}-${prx.prxPort}`);
-                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} Trojan/WS/${port == 443 ? "TLS" : "NTLS"} [${serviceName}]`;
+                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} Trojan/WS/${port == 443 ? "TLS" : "NTLS"}`;
                 } else if (protocol == "ss") { // Shadowsocks
                   uri.username = btoa(`none:${uuid}`);
                   uri.searchParams.set(
                     "plugin",
                     `${atob(v2)}-plugin${port == 80 ? "" : ";tls"};mux=0;mode=websocket;path=/${prx.prxIP}-${prx.prxPort};host=${APP_DOMAIN}`
                   );
-                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} Shadowsocks/WS/${port == 443 ? "TLS" : "NTLS"} [${serviceName}]`;
+                  uri.hash = `${result.length + 1} ${getFlagEmoji(prx.country)} ${prx.org} Shadowsocks/WS/${port == 443 ? "TLS" : "NTLS"}`;
                 }
 
                 result.push(uri.toString());


### PR DESCRIPTION
Removes the `[${serviceName}]` suffix from the `uri.hash` property for VLESS, Trojan, and Shadowsocks configurations. This prevents the worker name from being included when a user copies a configuration link.